### PR TITLE
updated buffer passed to unpack to address #6

### DIFF
--- a/adafruit_adxl34x.py
+++ b/adafruit_adxl34x.py
@@ -386,7 +386,7 @@ class ADXL345:
         with self._i2c as i2c:
             i2c.write(self._buffer, start=0, end=1)
             i2c.readinto(self._buffer, start=0, end=length)
-            return self._buffer
+            return self._buffer[0:length]
 
     def _write_register_byte(self, register, value):
         self._buffer[0] = register & 0xFF


### PR DESCRIPTION
This should fix the unpack error on linux/RPi in #6 . Tested by myself on a Neotrellis M4 and by @caternuson on a RPi