### PR TITLE
Delete unused _config_{iterrupt/interrupt}_register method

### DIFF
--- a/adafruit_adxl34x.py
+++ b/adafruit_adxl34x.py
@@ -394,7 +394,7 @@ class ADXL345:
         with self._i2c as i2c:
             i2c.write(self._buffer, start=0, end=2)
 
-    def _config_iterrupt_register(self, register, value):
+    def _config_interrupt_register(self, register, value):
         active_interrupts = self._read_register_unpacked(_REG_INT_ENABLE)
         self._write_register_byte(_REG_INT_ENABLE, 0x0) # disable interrupts for setup
         self._write_register_byte(register, value)

--- a/adafruit_adxl34x.py
+++ b/adafruit_adxl34x.py
@@ -394,12 +394,6 @@ class ADXL345:
         with self._i2c as i2c:
             i2c.write(self._buffer, start=0, end=2)
 
-    def _config_interrupt_register(self, register, value):
-        active_interrupts = self._read_register_unpacked(_REG_INT_ENABLE)
-        self._write_register_byte(_REG_INT_ENABLE, 0x0) # disable interrupts for setup
-        self._write_register_byte(register, value)
-        self._write_register_byte(_REG_INT_ENABLE, active_interrupts)
-
 class ADXL343(ADXL345):
     """
     Stub class for the ADXL343 3-axis accelerometer


### PR DESCRIPTION
Presumably you're not already using this method somewhere, otherwise this would be a breaking change.