### PR TITLE
Fix faulty ValueError message

### DIFF
--- a/adafruit_adxl34x.py
+++ b/adafruit_adxl34x.py
@@ -389,9 +389,7 @@ class ADXL345:
             self._write_register_byte(_REG_INT_ENABLE, active_interrupts)
             self._enabled_interrupts["tap"] = 2
         else:
-            raise ValueError(
-                "tap_count must be 1 for single tap or 2 for double tap"
-            )
+            raise ValueError("tap_count must be 1 for single tap or 2 for double tap")
 
     def disable_tap_detection(self) -> None:
         """Disable tap detection"""

--- a/adafruit_adxl34x.py
+++ b/adafruit_adxl34x.py
@@ -390,7 +390,7 @@ class ADXL345:
             self._enabled_interrupts["tap"] = 2
         else:
             raise ValueError(
-                "tap must be 0 to disable, 1 for single tap, or 2 for double tap"
+                "tap_count must be 1 for single tap or 2 for double tap"
             )
 
     def disable_tap_detection(self) -> None:


### PR DESCRIPTION
Fixes #36 which reports `0` as a valid option, when it is not.